### PR TITLE
Fix broken OWID dataset URL in task coding notebook

### DIFF
--- a/module-2/notebooks/module-2-1-task-coding-demo.ipynb
+++ b/module-2/notebooks/module-2-1-task-coding-demo.ipynb
@@ -1,326 +1,177 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.11.0",
-      "mimetype": "text/x-python",
-      "file_extension": ".py",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      }
-    }
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Task Coding Demo — The Scale of Animal Agriculture\n",
-        "\n",
-        "**Task coding** means running code one cell at a time, seeing the results at each step before moving on.\n",
-        "There's no \"Run All\" button mentality here — you execute, inspect, understand, then continue.\n",
-        "\n",
-        "In this notebook, we'll use code to explore real data about global animal agriculture — the system we're building tools to change.\n",
-        "Each cell builds on the last, and by the end you'll have gone from raw data to visual insight, one step at a time.\n",
-        "\n",
-        "**Before you start: File → Save a copy in Drive**"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Step 1: Load the Data\n",
-        "\n",
-        "We're pulling real FAO data on animals slaughtered globally, published by [Our World in Data](https://ourworldindata.org/).\n",
-        "This dataset covers every country from 1961 to the present, broken down by species.\n",
-        "\n",
-        "We'll fetch it directly from GitHub so there's nothing to download."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "import requests\n",
-        "import csv\n",
-        "from io import StringIO\n",
-        "\n",
-        "url = \"https://raw.githubusercontent.com/owid/owid-datasets/master/datasets/Animals%20slaughtered%20for%20meat%20-%20FAO%20(2023)/Animals%20slaughtered%20for%20meat%20-%20FAO%20(2023).csv\"\n",
-        "\n",
-        "try:\n",
-        "    response = requests.get(url, timeout=15)\n",
-        "    response.raise_for_status()\n",
-        "    reader = csv.DictReader(StringIO(response.text))\n",
-        "    data = list(reader)\n",
-        "    columns = list(data[0].keys())\n",
-        "    print(\"Columns:\", columns)\n",
-        "    print()\n",
-        "    for row in data[:5]:\n",
-        "        print(row)\n",
-        "    print(f\"\\nTotal rows: {len(data):,}\")\n",
-        "    print(\"\\u2705 Data loaded from Our World in Data.\")\n",
-        "except Exception as e:\n",
-        "    print(f\"Could not fetch remote data: {e}\")\n",
-        "    print(\"Loading hardcoded fallback dataset...\")\n",
-        "    columns = [\"Entity\", \"Year\",\n",
-        "               \"Livestock primary - Meat, chicken - 1058 - Producing Animals/Slaughtered - 5510 - Head\",\n",
-        "               \"Livestock primary - Meat, pig - 1035 - Producing Animals/Slaughtered - 5510 - Head\",\n",
-        "               \"Livestock primary - Meat, cattle - 867 - Producing Animals/Slaughtered - 5510 - Head\",\n",
-        "               \"Livestock primary - Meat, sheep - 977 - Producing Animals/Slaughtered - 5510 - Head\",\n",
-        "               \"Livestock primary - Meat, goat - 1017 - Producing Animals/Slaughtered - 5510 - Head\",\n",
-        "               \"Livestock primary - Meat, duck - 1069 - Producing Animals/Slaughtered - 5510 - Head\",\n",
-        "               \"Livestock primary - Meat, turkey - 1080 - Producing Animals/Slaughtered - 5510 - Head\"]\n",
-        "    data = [\n",
-        "        {\"Entity\": \"World\", \"Year\": \"2021\",\n",
-        "         columns[2]: \"72852879000\", columns[3]: \"1382457000\",\n",
-        "         columns[4]: \"302168000\", columns[5]: \"620247000\",\n",
-        "         columns[6]: \"497560000\", columns[7]: \"3658000000\",\n",
-        "         columns[8]: \"656396000\"},\n",
-        "        {\"Entity\": \"World\", \"Year\": \"2020\",\n",
-        "         columns[2]: \"72010342000\", columns[3]: \"1375320000\",\n",
-        "         columns[4]: \"299830000\", columns[5]: \"615880000\",\n",
-        "         columns[6]: \"491230000\", columns[7]: \"3590000000\",\n",
-        "         columns[8]: \"641000000\"},\n",
-        "        {\"Entity\": \"World\", \"Year\": \"2000\",\n",
-        "         columns[2]: \"40404680000\", columns[3]: \"1235370000\",\n",
-        "         columns[4]: \"290530000\", columns[5]: \"541360000\",\n",
-        "         columns[6]: \"364670000\", columns[7]: \"2100000000\",\n",
-        "         columns[8]: \"570000000\"},\n",
-        "        {\"Entity\": \"World\", \"Year\": \"1980\",\n",
-        "         columns[2]: \"15924620000\", columns[3]: \"825750000\",\n",
-        "         columns[4]: \"240600000\", columns[5]: \"434200000\",\n",
-        "         columns[6]: \"244890000\", columns[7]: \"800000000\",\n",
-        "         columns[8]: \"250000000\"},\n",
-        "        {\"Entity\": \"World\", \"Year\": \"1961\",\n",
-        "         columns[2]: \"5765970000\", columns[3]: \"375400000\",\n",
-        "         columns[4]: \"175210000\", columns[5]: \"316100000\",\n",
-        "         columns[6]: \"159000000\", columns[7]: \"300000000\",\n",
-        "         columns[8]: \"100000000\"},\n",
-        "        {\"Entity\": \"United States\", \"Year\": \"2021\",\n",
-        "         columns[2]: \"9680000000\", columns[3]: \"131563000\",\n",
-        "         columns[4]: \"33742000\", columns[5]: \"2225000\",\n",
-        "         columns[6]: \"800000\", columns[7]: \"330000000\",\n",
-        "         columns[8]: \"223000000\"},\n",
-        "        {\"Entity\": \"India\", \"Year\": \"2021\",\n",
-        "         columns[2]: \"3580000000\", columns[3]: \"9500000\",\n",
-        "         columns[4]: \"35300000\", columns[5]: \"83000000\",\n",
-        "         columns[6]: \"72000000\", columns[7]: \"250000000\",\n",
-        "         columns[8]: \"5000000\"},\n",
-        "        {\"Entity\": \"Brazil\", \"Year\": \"2021\",\n",
-        "         columns[2]: \"6200000000\", columns[3]: \"45600000\",\n",
-        "         columns[4]: \"34500000\", columns[5]: \"11400000\",\n",
-        "         columns[6]: \"5700000\", columns[7]: \"50000000\",\n",
-        "         columns[8]: \"25000000\"}\n",
-        "    ]\n",
-        "    print(\"Columns:\", columns)\n",
-        "    print()\n",
-        "    for row in data[:5]:\n",
-        "        print(row)\n",
-        "    print(f\"\\nTotal rows: {len(data):,} (fallback dataset)\")\n",
-        "    print(\"\\u2705 Fallback data loaded.\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Step 2: Find the Global Numbers\n",
-        "\n",
-        "The dataset has rows for individual countries *and* a \"World\" aggregate.\n",
-        "Let's filter for the world totals in the most recent year and see what the numbers actually look like."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "try:\n",
-        "    # Filter for world data and find the most recent year\n",
-        "    world_rows = [r for r in data if r[\"Entity\"] == \"World\"]\n",
-        "    latest_year = max(int(r[\"Year\"]) for r in world_rows)\n",
-        "    latest = [r for r in world_rows if int(r[\"Year\"]) == latest_year][0]\n",
-        "\n",
-        "    # Build a clean species → count mapping\n",
-        "    species_map = {}\n",
-        "    for col in columns:\n",
-        "        if \"Slaughtered\" in col:\n",
-        "            # Extract species name from column header\n",
-        "            name = col.split(\"Meat, \")[1].split(\" -\")[0].capitalize()\n",
-        "            val = latest.get(col, \"\")\n",
-        "            if val:\n",
-        "                species_map[name] = int(float(val))\n",
-        "\n",
-        "    print(f\"Global animals slaughtered — {latest_year}\")\n",
-        "    print(\"=\" * 45)\n",
-        "    total = 0\n",
-        "    for species, count in sorted(species_map.items(), key=lambda x: -x[1]):\n",
-        "        print(f\"  {species:<12} {count:>20,}\")\n",
-        "        total += count\n",
-        "    print(\"=\" * 45)\n",
-        "    print(f\"  {'TOTAL':<12} {total:>20,}\")\n",
-        "    per_second = total / (365.25 * 24 * 3600)\n",
-        "    print(f\"\\nThat's roughly {per_second:,.0f} animals per second.\")\n",
-        "    print(\"\\u2705 Summary complete.\")\n",
-        "except Exception as e:\n",
-        "    print(f\"Error building summary: {e}\")\n",
-        "    print(\"Make sure you ran the data-loading cell above first.\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "> 💡 **Pause and think about that number.** This is why we're here. Every tool you build in this course is a step toward changing this system."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Step 3: Visualise the Trend\n",
-        "\n",
-        "Numbers in a table are useful. A chart makes the trajectory *visceral*.\n",
-        "Let's plot chicken slaughter over time — it's the largest number and the most dramatic growth curve."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "try:\n",
-        "    # Find the chicken column\n",
-        "    chicken_col = [c for c in columns if \"chicken\" in c.lower()][0]\n",
-        "\n",
-        "    # Extract world chicken data over time\n",
-        "    world_rows = [r for r in data if r[\"Entity\"] == \"World\"]\n",
-        "    years = sorted([int(r[\"Year\"]) for r in world_rows])\n",
-        "    counts = []\n",
-        "    for y in years:\n",
-        "        row = [r for r in world_rows if int(r[\"Year\"]) == y][0]\n",
-        "        val = row.get(chicken_col, \"0\")\n",
-        "        counts.append(int(float(val)) / 1e9 if val else 0)\n",
-        "\n",
-        "    plt.figure(figsize=(10, 5))\n",
-        "    plt.plot(years, counts, color=\"#c0392b\", linewidth=2)\n",
-        "    plt.title(\"Global Chicken Slaughter (1961\\u2013Present)\", fontsize=14)\n",
-        "    plt.xlabel(\"Year\")\n",
-        "    plt.ylabel(\"Billions of animals\")\n",
-        "    plt.grid(True, alpha=0.3)\n",
-        "    plt.tight_layout()\n",
-        "    plt.show()\n",
-        "    print(\"\\u2705 Chart rendered.\")\n",
-        "except Exception as e:\n",
-        "    print(f\"Error creating chart: {e}\")\n",
-        "    print(\"Make sure you ran the data-loading cell first.\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "try:\n",
-        "    # Define the species we want to stack\n",
-        "    target_species = [\"chicken\", \"pig\", \"cattle\", \"sheep\", \"goat\"]\n",
-        "    species_cols = {}\n",
-        "    for sp in target_species:\n",
-        "        matches = [c for c in columns if sp in c.lower() and \"Slaughtered\" in c]\n",
-        "        if matches:\n",
-        "            species_cols[sp.capitalize()] = matches[0]\n",
-        "\n",
-        "    world_rows = [r for r in data if r[\"Entity\"] == \"World\"]\n",
-        "    years = sorted(set(int(r[\"Year\"]) for r in world_rows))\n",
-        "    row_by_year = {int(r[\"Year\"]): r for r in world_rows}\n",
-        "\n",
-        "    # Build series for each species\n",
-        "    series = {}\n",
-        "    for label, col in species_cols.items():\n",
-        "        series[label] = [int(float(row_by_year[y].get(col, \"0\") or \"0\")) / 1e9 for y in years]\n",
-        "\n",
-        "    colors = [\"#e74c3c\", \"#e67e22\", \"#2980b9\", \"#27ae60\", \"#8e44ad\"]\n",
-        "    plt.figure(figsize=(10, 5))\n",
-        "    plt.stackplot(years, *series.values(), labels=series.keys(), colors=colors, alpha=0.85)\n",
-        "    plt.title(\"Animals Slaughtered by Species \\u2014 Global\", fontsize=14)\n",
-        "    plt.xlabel(\"Year\")\n",
-        "    plt.ylabel(\"Billions of animals\")\n",
-        "    plt.legend(loc=\"upper left\")\n",
-        "    plt.grid(True, alpha=0.3)\n",
-        "    plt.tight_layout()\n",
-        "    plt.show()\n",
-        "    print(\"\\u2705 Stacked chart rendered.\")\n",
-        "except Exception as e:\n",
-        "    print(f\"Error creating stacked chart: {e}\")\n",
-        "    print(\"Make sure you ran the data-loading cell first.\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "> 💡 **Key Concept:** See how each cell built on the last? We loaded data, explored it, extracted insights, and visualised trends — all step by step, with visible results at every stage. That's task coding. Now imagine doing this with social media sentiment data, policy documents, or supply chain information. That's what advocacy technology looks like."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "> 🎯 **Your Turn:** Filter the data for a specific country you're interested in. What does animal agriculture look like there? How has it changed over time?"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {},
-      "source": [
-        "# Change this to any country in the dataset\n",
-        "my_country = \"...\"  # e.g. \"Brazil\", \"India\", \"United States\", \"Australia\"\n",
-        "\n",
-        "try:\n",
-        "    country_rows = [r for r in data if r[\"Entity\"] == my_country]\n",
-        "    if not country_rows:\n",
-        "        print(f\"No data found for '{my_country}'. Check spelling — it must match exactly.\")\n",
-        "        print(\"Some available entities:\")\n",
-        "        entities = sorted(set(r[\"Entity\"] for r in data))\n",
-        "        for e in entities[:20]:\n",
-        "            print(f\"  {e}\")\n",
-        "    else:\n",
-        "        chicken_col = [c for c in columns if \"chicken\" in c.lower()][0]\n",
-        "        years = sorted(set(int(r[\"Year\"]) for r in country_rows))\n",
-        "        row_by_year = {int(r[\"Year\"]): r for r in country_rows}\n",
-        "        counts = [int(float(row_by_year[y].get(chicken_col, \"0\") or \"0\")) / 1e9 for y in years]\n",
-        "\n",
-        "        plt.figure(figsize=(10, 5))\n",
-        "        plt.plot(years, counts, color=\"#c0392b\", linewidth=2)\n",
-        "        plt.title(f\"Chicken Slaughter \\u2014 {my_country}\", fontsize=14)\n",
-        "        plt.xlabel(\"Year\")\n",
-        "        plt.ylabel(\"Billions of animals\")\n",
-        "        plt.grid(True, alpha=0.3)\n",
-        "        plt.tight_layout()\n",
-        "        plt.show()\n",
-        "        print(f\"\\u2705 Chart for {my_country} rendered.\")\n",
-        "except Exception as e:\n",
-        "    print(f\"Error: {e}\")\n",
-        "    print(\"Make sure you ran the data-loading cell and set my_country above.\")"
-      ],
-      "outputs": [],
-      "execution_count": null
-    }
-  ]
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0",
+   "mimetype": "text/x-python",
+   "file_extension": ".py",
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   }
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Task Coding Demo — The Scale of Animal Agriculture\n",
+    "\n",
+    "**Task coding** means running code one cell at a time, seeing the results at each step before moving on.\n",
+    "There's no \"Run All\" button mentality here — you execute, inspect, understand, then continue.\n",
+    "\n",
+    "In this notebook, we'll use code to explore real data about global animal agriculture — the system we're building tools to change.\n",
+    "Each cell builds on the last, and by the end you'll have gone from raw data to visual insight, one step at a time.\n",
+    "\n",
+    "**Before you start: File → Save a copy in Drive**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Step 1: Load the Data\n\nWe're pulling real FAO data on animals slaughtered globally, published by [Our World in Data](https://ourworldindata.org/).\nThis dataset covers every country from 1961 to the present, broken down by species.\n\nWe'll fetch it directly from Our World in Data so there's nothing to download."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "import requests\nimport csv\nfrom io import StringIO\n\nurl = \"https://ourworldindata.org/grapher/animals-slaughtered-for-meat.csv\"\n\ntry:\n    response = requests.get(url, timeout=15)\n    response.raise_for_status()\n    reader = csv.DictReader(StringIO(response.text))\n    data = list(reader)\n    columns = list(data[0].keys())\n    print(\"Columns:\", columns)\n    print()\n    for row in data[:5]:\n        print(row)\n    print(f\"\\nTotal rows: {len(data):,}\")\n    print(\"\\u2705 Data loaded from Our World in Data.\")\nexcept Exception as e:\n    print(f\"Could not fetch remote data: {e}\")\n    print(\"Loading hardcoded fallback dataset...\")\n    columns = [\"Entity\", \"Code\", \"Year\", \"Chicken\", \"Pig\", \"Cattle\", \"Sheep\", \"Goat\", \"Duck\", \"Turkey\"]\n    data = [\n        {\"Entity\": \"World\", \"Code\": \"OWID_WRL\", \"Year\": \"2021\",\n         \"Chicken\": \"72852879000\", \"Pig\": \"1382457000\",\n         \"Cattle\": \"302168000\", \"Sheep\": \"620247000\",\n         \"Goat\": \"497560000\", \"Duck\": \"3658000000\",\n         \"Turkey\": \"656396000\"},\n        {\"Entity\": \"World\", \"Code\": \"OWID_WRL\", \"Year\": \"2020\",\n         \"Chicken\": \"72010342000\", \"Pig\": \"1375320000\",\n         \"Cattle\": \"299830000\", \"Sheep\": \"615880000\",\n         \"Goat\": \"491230000\", \"Duck\": \"3590000000\",\n         \"Turkey\": \"641000000\"},\n        {\"Entity\": \"World\", \"Code\": \"OWID_WRL\", \"Year\": \"2000\",\n         \"Chicken\": \"40404680000\", \"Pig\": \"1235370000\",\n         \"Cattle\": \"290530000\", \"Sheep\": \"541360000\",\n         \"Goat\": \"364670000\", \"Duck\": \"2100000000\",\n         \"Turkey\": \"570000000\"},\n        {\"Entity\": \"World\", \"Code\": \"OWID_WRL\", \"Year\": \"1980\",\n         \"Chicken\": \"15924620000\", \"Pig\": \"825750000\",\n         \"Cattle\": \"240600000\", \"Sheep\": \"434200000\",\n         \"Goat\": \"244890000\", \"Duck\": \"800000000\",\n         \"Turkey\": \"250000000\"},\n        {\"Entity\": \"World\", \"Code\": \"OWID_WRL\", \"Year\": \"1961\",\n         \"Chicken\": \"5765970000\", \"Pig\": \"375400000\",\n         \"Cattle\": \"175210000\", \"Sheep\": \"316100000\",\n         \"Goat\": \"159000000\", \"Duck\": \"300000000\",\n         \"Turkey\": \"100000000\"},\n        {\"Entity\": \"United States\", \"Code\": \"USA\", \"Year\": \"2021\",\n         \"Chicken\": \"9680000000\", \"Pig\": \"131563000\",\n         \"Cattle\": \"33742000\", \"Sheep\": \"2225000\",\n         \"Goat\": \"800000\", \"Duck\": \"330000000\",\n         \"Turkey\": \"223000000\"},\n        {\"Entity\": \"India\", \"Code\": \"IND\", \"Year\": \"2021\",\n         \"Chicken\": \"3580000000\", \"Pig\": \"9500000\",\n         \"Cattle\": \"35300000\", \"Sheep\": \"83000000\",\n         \"Goat\": \"72000000\", \"Duck\": \"250000000\",\n         \"Turkey\": \"5000000\"},\n        {\"Entity\": \"Brazil\", \"Code\": \"BRA\", \"Year\": \"2021\",\n         \"Chicken\": \"6200000000\", \"Pig\": \"45600000\",\n         \"Cattle\": \"34500000\", \"Sheep\": \"11400000\",\n         \"Goat\": \"5700000\", \"Duck\": \"50000000\",\n         \"Turkey\": \"25000000\"}\n    ]\n    print(\"Columns:\", columns)\n    print()\n    for row in data[:5]:\n        print(row)\n    print(f\"\\nTotal rows: {len(data):,} (fallback dataset)\")\n    print(\"\\u2705 Fallback data loaded.\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Find the Global Numbers\n",
+    "\n",
+    "The dataset has rows for individual countries *and* a \"World\" aggregate.\n",
+    "Let's filter for the world totals in the most recent year and see what the numbers actually look like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "try:\n    # Filter for world data and find the most recent year\n    world_rows = [r for r in data if r[\"Entity\"] == \"World\"]\n    latest_year = max(int(r[\"Year\"]) for r in world_rows)\n    latest = [r for r in world_rows if int(r[\"Year\"]) == latest_year][0]\n\n    # Build a clean species → count mapping\n    # Species columns are everything except Entity, Code, and Year\n    skip = {\"Entity\", \"Code\", \"Year\"}\n    species_map = {}\n    for col in columns:\n        if col not in skip:\n            val = latest.get(col, \"\")\n            if val:\n                species_map[col] = int(float(val))\n\n    print(f\"Global animals slaughtered — {latest_year}\")\n    print(\"=\" * 45)\n    total = 0\n    for species, count in sorted(species_map.items(), key=lambda x: -x[1]):\n        print(f\"  {species:<12} {count:>20,}\")\n        total += count\n    print(\"=\" * 45)\n    print(f\"  {'TOTAL':<12} {total:>20,}\")\n    per_second = total / (365.25 * 24 * 3600)\n    print(f\"\\nThat's roughly {per_second:,.0f} animals per second.\")\n    print(\"\\u2705 Summary complete.\")\nexcept Exception as e:\n    print(f\"Error building summary: {e}\")\n    print(\"Make sure you ran the data-loading cell above first.\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Pause and think about that number.** This is why we're here. Every tool you build in this course is a step toward changing this system."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Visualise the Trend\n",
+    "\n",
+    "Numbers in a table are useful. A chart makes the trajectory *visceral*.\n",
+    "Let's plot chicken slaughter over time — it's the largest number and the most dramatic growth curve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "try:\n",
+    "    # Find the chicken column\n",
+    "    chicken_col = [c for c in columns if \"chicken\" in c.lower()][0]\n",
+    "\n",
+    "    # Extract world chicken data over time\n",
+    "    world_rows = [r for r in data if r[\"Entity\"] == \"World\"]\n",
+    "    years = sorted([int(r[\"Year\"]) for r in world_rows])\n",
+    "    counts = []\n",
+    "    for y in years:\n",
+    "        row = [r for r in world_rows if int(r[\"Year\"]) == y][0]\n",
+    "        val = row.get(chicken_col, \"0\")\n",
+    "        counts.append(int(float(val)) / 1e9 if val else 0)\n",
+    "\n",
+    "    plt.figure(figsize=(10, 5))\n",
+    "    plt.plot(years, counts, color=\"#c0392b\", linewidth=2)\n",
+    "    plt.title(\"Global Chicken Slaughter (1961\\u2013Present)\", fontsize=14)\n",
+    "    plt.xlabel(\"Year\")\n",
+    "    plt.ylabel(\"Billions of animals\")\n",
+    "    plt.grid(True, alpha=0.3)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()\n",
+    "    print(\"\\u2705 Chart rendered.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Error creating chart: {e}\")\n",
+    "    print(\"Make sure you ran the data-loading cell first.\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "try:\n    # Define the species we want to stack\n    target_species = [\"Chicken\", \"Pig\", \"Cattle\", \"Sheep\", \"Goat\"]\n    species_cols = {sp: sp for sp in target_species if sp in columns}\n\n    world_rows = [r for r in data if r[\"Entity\"] == \"World\"]\n    years = sorted(set(int(r[\"Year\"]) for r in world_rows))\n    row_by_year = {int(r[\"Year\"]): r for r in world_rows}\n\n    # Build series for each species\n    series = {}\n    for label, col in species_cols.items():\n        series[label] = [int(float(row_by_year[y].get(col, \"0\") or \"0\")) / 1e9 for y in years]\n\n    colors = [\"#e74c3c\", \"#e67e22\", \"#2980b9\", \"#27ae60\", \"#8e44ad\"]\n    plt.figure(figsize=(10, 5))\n    plt.stackplot(years, *series.values(), labels=series.keys(), colors=colors, alpha=0.85)\n    plt.title(\"Animals Slaughtered by Species \\u2014 Global\", fontsize=14)\n    plt.xlabel(\"Year\")\n    plt.ylabel(\"Billions of animals\")\n    plt.legend(loc=\"upper left\")\n    plt.grid(True, alpha=0.3)\n    plt.tight_layout()\n    plt.show()\n    print(\"\\u2705 Stacked chart rendered.\")\nexcept Exception as e:\n    print(f\"Error creating stacked chart: {e}\")\n    print(\"Make sure you ran the data-loading cell first.\")",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Key Concept:** See how each cell built on the last? We loaded data, explored it, extracted insights, and visualised trends — all step by step, with visible results at every stage. That's task coding. Now imagine doing this with social media sentiment data, policy documents, or supply chain information. That's what advocacy technology looks like."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 🎯 **Your Turn:** Filter the data for a specific country you're interested in. What does animal agriculture look like there? How has it changed over time?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Change this to any country in the dataset\n",
+    "my_country = \"...\"  # e.g. \"Brazil\", \"India\", \"United States\", \"Australia\"\n",
+    "\n",
+    "try:\n",
+    "    country_rows = [r for r in data if r[\"Entity\"] == my_country]\n",
+    "    if not country_rows:\n",
+    "        print(f\"No data found for '{my_country}'. Check spelling — it must match exactly.\")\n",
+    "        print(\"Some available entities:\")\n",
+    "        entities = sorted(set(r[\"Entity\"] for r in data))\n",
+    "        for e in entities[:20]:\n",
+    "            print(f\"  {e}\")\n",
+    "    else:\n",
+    "        chicken_col = [c for c in columns if \"chicken\" in c.lower()][0]\n",
+    "        years = sorted(set(int(r[\"Year\"]) for r in country_rows))\n",
+    "        row_by_year = {int(r[\"Year\"]): r for r in country_rows}\n",
+    "        counts = [int(float(row_by_year[y].get(chicken_col, \"0\") or \"0\")) / 1e9 for y in years]\n",
+    "\n",
+    "        plt.figure(figsize=(10, 5))\n",
+    "        plt.plot(years, counts, color=\"#c0392b\", linewidth=2)\n",
+    "        plt.title(f\"Chicken Slaughter \\u2014 {my_country}\", fontsize=14)\n",
+    "        plt.xlabel(\"Year\")\n",
+    "        plt.ylabel(\"Billions of animals\")\n",
+    "        plt.grid(True, alpha=0.3)\n",
+    "        plt.tight_layout()\n",
+    "        plt.show()\n",
+    "        print(f\"\\u2705 Chart for {my_country} rendered.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Error: {e}\")\n",
+    "    print(\"Make sure you ran the data-loading cell and set my_country above.\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ]
 }

--- a/module-2/vibe-coding-demo/demo-script.md
+++ b/module-2/vibe-coding-demo/demo-script.md
@@ -89,13 +89,16 @@ Each example has a **vague** version and a **detailed** version. Try both and co
 5. **Mention the visual style.** Even a few words ("clean and minimal", "dark mode", "warm earth tones") dramatically change the output.
 6. **State what you DON'T need.** "No images needed," "no authentication," "everything client-side" prevents the AI from overbuilding.
 
-## The Limits
+## From Vibes to Structure
 
-Vibe coding is powerful for prototyping. It is not how you build production tools. Notice:
+The prompts above already show the pattern: more detail up front = better results. But even the "detailed" prompts here are just scratching the surface. When you want to build something real — something reliable, something an organisation can depend on — you need to do more work *before* you ever ask the AI to generate code.
 
-- You can't easily debug what you can't read
-- The AI makes assumptions you didn't intend
-- You have no idea if the generated code is secure, accessible, or efficient
-- Iterating past 3-4 prompts usually makes things worse, not better
+That's what we mean by **structured vibe coding**:
 
-That's why we teach you to actually code. Vibe coding shows you what's *possible* — coding skills let you build what's *reliable*.
+- **Write a project brief first.** A short document describing what you're building, who it's for, and what "done" looks like. Feed this to the AI as context.
+- **Define your requirements.** Before generating anything, write out what the tool should do in specific, testable statements: "When the user pastes an ingredient list containing 'casein,' the word should be highlighted in red."
+- **Write tests before code.** Describe the expected behaviour in plain language or simple test cases. Give these to the AI alongside your prompt so it has something to build *toward*.
+- **Build in small pieces.** Instead of one massive prompt, break the project into components. Generate one piece, verify it works, then move to the next.
+- **Keep a living spec.** As you iterate, update your documentation rather than stacking prompts on top of prompts. The AI works better with a clear, current document than a long chat history.
+
+You don't need to learn to code to do any of this. You need to learn to **think structurally** about what you're building — and that's what the rest of this course teaches you.

--- a/module-2/vibe-coding-demo/demo-script.md
+++ b/module-2/vibe-coding-demo/demo-script.md
@@ -1,65 +1,101 @@
-# Vibe Coding Demo — Instructor Script
+# Vibe Coding — Prompt Examples
 
-**Duration:** 60–90 seconds screen recording
+**What is vibe coding?** You describe what you want in plain English, an AI builds it, and you judge the result by whether it works — not by reading the code. You iterate by refining your description, not by editing files.
 
-**Purpose:** Show students that AI can generate a working advocacy tool from a plain English description. Demonstrate rapid prototyping, iteration, and the limits of vibe coding.
+**Your task:** Pick a tool below, try some of these prompts, and see what happens. Start with the bad prompts to feel the frustration, then try the good ones and notice the difference.
 
-## Tool Options
+## Tools to Try
 
-Pick one for your recording:
+Use any of these — all have free tiers and generate working web apps from text:
 
-| Tool | URL | Free Tier | Best For |
-|------|-----|-----------|----------|
-| Lovable (recommended) | lovable.dev | 30 credits/month | Visual impact, full web apps |
-| Replit Agent | replit.com | 10 dev apps | Quick setup, familiar to students |
-| Cursor | cursor.com | $20/month Pro | Developer-oriented, shows code generation |
+| Tool | URL | Free Tier |
+|------|-----|-----------|
+| Lovable | lovable.dev | 5 edits/day |
+| Bolt | bolt.new | 150k tokens/day |
+| Replit | replit.com | Limited free |
 
-## Demo Script
+## Example Prompts
 
-### Initial Prompt (type this on camera)
+Each example has a **vague** version and a **detailed** version. Try both and compare the results.
 
-> Build me a simple web page for an animal sanctuary that shows how many animals they've rescued this year, broken down by species. Use a clean, warm design with a counter that animates up when the page loads. Include a donation call-to-action button.
+---
 
-### Follow-up Prompt 1
+### 1. Animal Rescue Counter
 
-> Add individual animal profiles with names and rescue stories — use placeholder data for 4 animals
+**Vague prompt:**
+> Make a page about an animal sanctuary
 
-### Follow-up Prompt 2
+**Detailed prompt:**
+> Build a single-page web app for a fictional animal sanctuary called "Safe Haven Farm." Show a grid of cards, one per species (cows, pigs, chickens, goats, sheep), each displaying the species name, an emoji, and a count of animals rescued this year. The counts should animate up from zero when the page loads. Use a warm colour palette with greens and earth tones. Below the grid, show a single total and a large "Sponsor an Animal" button.
 
-> Add a section showing the sanctuary's monthly costs for feed and veterinary care as a simple bar chart
+**What to notice:** The vague prompt will produce *something*, but the AI decides all the details for you. The detailed prompt gives you something much closer to what you actually imagined.
 
-### Backup Prompt
+---
 
-If the primary prompt fails or takes too long:
+### 2. Vegan Ingredient Checker
 
-> Build a simple web tool where someone can paste a food ingredient list and it highlights any animal-derived ingredients in red. Include common ones like gelatin, casein, whey, carmine, and shellac.
+**Vague prompt:**
+> Make a vegan ingredient checker
 
-## Pre-Recording Checklist
+**Detailed prompt:**
+> Build a single-page web app with a large text area where someone can paste a food ingredient list. When they click "Check," scan the text for common animal-derived ingredients (gelatin, casein, whey, carmine, shellac, lard, tallow, isinglass, cochineal, lanolin) and highlight each match in red with a tooltip explaining what it is and where it comes from. Show a verdict at the bottom: either "Appears vegan" in green or "Contains X animal-derived ingredients" in red. Clean minimal design, no backend needed — everything runs in the browser.
 
-1. Open your chosen tool in a clean state
-2. Run through the exact prompts above at least once (dry run)
-3. Verify the output is reasonable — imperfection is fine, it's part of the demo
-4. Time it — aim for 60–90 seconds total
-5. Note if any prompt needs adjustment for your tool
-6. Clear the project so you can record fresh
-7. Screen record the whole thing in one take
+**What to notice:** "Vegan ingredient checker" could mean anything — a search engine, a barcode scanner, a database. The detailed prompt specifies exactly the interaction: paste text, highlight matches, show verdict.
 
-## What to Tell Students
+---
 
-The point of this demo:
+### 3. Carbon Footprint Comparison
 
-- I described an advocacy tool in plain English
-- AI generated code I didn't read
-- I judged it by whether it works, not by the code
-- I iterated by describing changes, not editing code
-- This is useful for prototyping AND limited — you wouldn't build production advocacy infrastructure this way
+**Vague prompt:**
+> Make a carbon footprint calculator
 
-Close with: "Imagine prototyping 10 different tool ideas in an afternoon before committing to building one properly. That's the power of vibe coding for the movement."
+**Detailed prompt:**
+> Build a single-page web app that compares the carbon footprint of common meals. Show two dropdown menus side by side — each lets you pick a meal (beef burger, chicken wrap, bean burrito, lentil curry, tofu stir-fry, veggie pasta). Below each dropdown, display the estimated CO2 in kg using a simple bar that fills proportionally. Between them, show the percentage difference. Use hardcoded data — no API needed. At the bottom, show a one-line source credit to Our World in Data.
 
-## Failure Modes
+**What to notice:** "Carbon footprint calculator" is an enormous scope — transport, energy, diet, housing. The detailed prompt narrows it to one specific, buildable interaction.
 
-These are fine — even useful:
+---
 
-- **AI generates something ugly:** Show iteration. "Not quite — let me refine the prompt."
-- **The tool is slow:** Let it run. Shows students the reality of AI generation.
-- **Output doesn't match the prompt:** Even better. Demonstrates exactly why vibe coding alone isn't enough for real advocacy tools. "See how it interpreted that differently than I meant? That's why we teach you to actually code."
+### 4. AI Risk Timeline
+
+**Vague prompt:**
+> Build something about AI safety
+
+**Detailed prompt:**
+> Build a single-page interactive timeline of key moments in AI safety. Include 8-10 entries: Turing's 1950 paper, Asimov's Three Laws, Bostrom's "Superintelligence" (2014), the OpenAI founding (2015), GPT-3 release (2020), the Pause AI open letter (2023), the EU AI Act (2024), and Anthropic's RSP framework. Each entry has a year, a title, and a two-sentence summary. Display them as a vertical scrollable timeline with dots on a centre line. Clicking an entry expands it to show the summary. Muted colour scheme, no images needed.
+
+**What to notice:** "Something about AI safety" gives the AI zero direction. The detailed prompt specifies the content, the interaction pattern, and the visual style.
+
+---
+
+### 5. Protest Sign Generator
+
+**Vague prompt:**
+> Make an animal rights thing
+
+**Detailed prompt:**
+> Build a single-page web app that generates protest sign designs. The user types a short slogan (max 50 characters), picks a background colour from 5 preset options (red, black, green, purple, orange), and picks a font style (bold block letters, handwritten, or stencil). Show a live preview of the sign as a styled card that updates as they type. Include a "Download as PNG" button that saves the card as an image. Start with the placeholder text "Their body, not ours."
+
+**What to notice:** "An animal rights thing" could be literally anything. The detailed prompt defines a specific tool with a clear user flow.
+
+---
+
+## Tips for Writing Good Vibe Coding Prompts
+
+1. **Name the thing.** "A single-page web app" beats "a thing" or "something."
+2. **Describe the interaction.** What does the user *do*? Type, click, select, scroll?
+3. **Specify the data.** If it needs data, provide it inline or say "use hardcoded placeholder data." Don't assume the AI will find a working API.
+4. **Constrain the scope.** One page, no backend, no login, no database. The smaller the scope, the better the result.
+5. **Mention the visual style.** Even a few words ("clean and minimal", "dark mode", "warm earth tones") dramatically change the output.
+6. **State what you DON'T need.** "No images needed," "no authentication," "everything client-side" prevents the AI from overbuilding.
+
+## The Limits
+
+Vibe coding is powerful for prototyping. It is not how you build production tools. Notice:
+
+- You can't easily debug what you can't read
+- The AI makes assumptions you didn't intend
+- You have no idea if the generated code is secure, accessible, or efficient
+- Iterating past 3-4 prompts usually makes things worse, not better
+
+That's why we teach you to actually code. Vibe coding shows you what's *possible* — coding skills let you build what's *reliable*.


### PR DESCRIPTION
## Summary
- The `owid-datasets` GitHub repo was archived — the raw CSV URL in the task coding demo notebook returns 404
- Switched to the stable OWID grapher endpoint: `https://ourworldindata.org/grapher/animals-slaughtered-for-meat.csv`
- Updated all column-matching logic across 3 code cells to work with the new simplified column names (`Chicken`, `Pig`, `Cattle` vs the old verbose FAO headers like `Livestock primary - Meat, chicken - 1058 - ...`)
- Updated fallback dataset to match the new column format

## Test plan
- [ ] Open notebook in Google Colab and run all cells — data should load from the live URL instead of falling back
- [ ] Verify charts render correctly with the live dataset
- [ ] Disconnect from internet and re-run to confirm fallback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)