### PR TITLE
chore: prepare repo for public visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+node_modules/
+dist/
+build/
+.env
+.env.local
+.env.*.local
+*.log
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo
+coverage/
+.turbo/


### PR DESCRIPTION
## Summary
- Add .gitignore (Node/TS)

Part of org-wide public readiness preparation.