### PR TITLE
[Repo Health] c4c-bootcamp: AGT fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,15 @@ module-2/                        # Coding Foundations module
 | `module-2/vibe-coding-demo/demo-script.md` | Reproducible vibe coding demo |
 | `.gitmodules` | Submodule references |
 
+## Agent Context Files
+
+| File | What It Documents |
+|------|------------------|
+| `module-2/CLAUDE.md` | Module 2 overview — learning arc, subdirectory index, API table |
+| `module-2/notebooks/CLAUDE.md` | Per-notebook summaries with APIs, libraries, and key concepts |
+| `module-2/project-pitches/CLAUDE.md` | File inventory, workflow steps, instructor notes |
+| `module-2/vibe-coding-demo/CLAUDE.md` | Demo script contents, session flow, pedagogical purpose |
+
 ## Development
 
 - **Tech stack:** Python 3, Google Colab, OpenRouter, OpenFoodFacts API, Our World in Data

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,65 @@ module-2/                        # Coding Foundations module
 - **Adding modules:** Create `module-N/` directory following the existing pattern
 - **Adding notebooks:** Place in `module-N/notebooks/`, ensure they run in Colab without local deps
 - **Project pitches directory** is designed to be published as a separate repo (`c4c-project-pitches`) for students to fork
+
+## Organizational Context
+
+**Layer:** 1 | **Lever:** Strengthen | **Integration:** Curriculum content for the bootcamp pipeline
+
+This is the teaching content that turns developers into advocacy technologists. Entry point of the Layer 1 flywheel (Bootcamp → Hackathon → Guild → RDP). The India community launch (May 2026, Bengaluru + Mumbai) will use these materials.
+
+**Settled decisions affecting this repo:**
+- **2026-04-02: Bootcamp identity framing** — Month 1 introduces advocacy context through real APIs (FAO slaughter data, OpenFoodFacts) and the ubiquitous language dictionary framed as practical communication. No explicit liberation rhetoric in early modules. Liberation framing develops through the work.
+- **2026-04-02: Graze-CLI architecture** — Graze-CLI will integrate as a CLAUDE.md template / Claude Code extension. Do NOT write it into curriculum until it has been smoke-tested on a non-core-team machine.
+- **2026-03-25: Graze-CLI needs smoke test before curriculum** — Sam coordinates; bootcamp launch is not blocked by this.
+
+**Relevant strategy documents:**
+- `programs/developer-training-pipeline/guild/operations.md` — full Guild pipeline
+- `programs/developer-training-pipeline/india-community/community-strategy.md` — May 2026 India launch
+- `ecosystem/repos.md` — `structured-coding-with-ai` should be referenced in bootcamp curriculum
+
+**Current status:** Active. Tutorial quest content due 2 weeks before May 2026 launch (Abid owns). Bootcamp launch is not blocked by Graze-CLI smoke test — those are parallel tracks.
+
+## Development Standards
+
+### 10-Point Review Checklist (ranked by AI violation frequency)
+
+1. **DRY** — AI clones code at 4x the human rate. Search before writing anything new
+2. **Deep modules** — Reject shallow wrappers and pass-through methods. Interface must be simpler than implementation
+3. **Single responsibility** — Each function does one thing at one level of abstraction
+4. **Error handling** — Never catch-all. Every catch block must handle specifically
+5. **Information hiding** — Don't expose internal state. Mask API keys (last 4 chars only)
+6. **Ubiquitous language** — Use movement terminology consistently. Never let AI invent synonyms for domain terms
+7. **Design for change** — Abstraction layers and loose coupling
+8. **Legacy velocity** — Use characterization tests before modifying existing notebooks
+9. **Over-patterning** — Simplest structure that works
+10. **Test quality** — Every test must fail when the covered behavior breaks
+
+### Quality Gates
+
+- **Desloppify:** `desloppify scan --path .` — minimum score ≥85
+- **Speciesist language:** `semgrep --config semgrep-no-animal-violence.yaml` on all notebook and docs edits
+- **Two-failure rule:** After two failed fixes on the same problem, stop and restart with a better approach
+
+### Seven Concerns — Critical for This Repo
+
+All 7 concerns apply. Highlighted critical ones:
+
+- **Advocacy domain** (critical) — Bootcamp materials DEFINE how new developers learn movement terminology. Use precise terms: **farmed animal** (not "livestock"), **factory farm** (not "farm"), **slaughterhouse** (not "processing facility"). The ubiquitous language dictionary should be introduced in Month 1.3.
+- **Accessibility** (critical) — Content is for India developers on constrained connections. Notebooks must run on Google Colab free tier. Minimize large downloads.
+- **Emotional safety** — FAO slaughter data produces numbers representing animal deaths. Frame appropriately for students encountering this data for the first time.
+- **Cost optimization** — OpenRouter usage in notebooks must use free or cheapest capable models. Students should not face unexpected API costs.
+- **Security** — API keys in notebooks must use environment variables or Colab secrets, never hardcoded.
+
+### Advocacy Domain Language
+
+Bootcamp materials shape how the next cohort thinks. Use these terms precisely:
+- **Farmed animal** — not "livestock" (industry framing normalizes commodification)
+- **Factory farm** — not "farm" (scale and conditions matter)
+- **Slaughterhouse** — use precisely in any data analysis context
+- **Campaign** — organized advocacy effort (not "project")
+- **Activist** — person engaged in advocacy work (not "user")
+
+### Structured Coding Reference
+
+For tool-specific AI coding instructions (Claude Code rules, Cursor MDC, Copilot, Windsurf, etc.), copy the corresponding directory from `structured-coding-with-ai` into this project root.

--- a/module-2/CLAUDE.md
+++ b/module-2/CLAUDE.md
@@ -1,0 +1,43 @@
+# Module 2 — Coding Foundations
+
+The first hands-on coding module of the C4C bootcamp. Students go from zero to making real API calls and LLM requests — all using advocacy data and movement APIs.
+
+## Structure
+
+```
+module-2/
+├── notebooks/          # 3 Google Colab teaching notebooks
+├── project-pitches/    # GitHub fork/branch/PR exercise (publishable as c4c-project-pitches)
+└── vibe-coding-demo/   # Prompt examples for live/recorded vibe coding session
+```
+
+## Subdirectory Docs
+
+| Directory | CLAUDE.md | What It Covers |
+|-----------|-----------|----------------|
+| `notebooks/` | [`notebooks/CLAUDE.md`](notebooks/CLAUDE.md) | Per-notebook summaries: what each teaches, APIs used, key concepts |
+| `project-pitches/` | [`project-pitches/CLAUDE.md`](project-pitches/CLAUDE.md) | GitHub workflow exercise, file inventory, instructor notes |
+| `vibe-coding-demo/` | [`vibe-coding-demo/CLAUDE.md`](vibe-coding-demo/CLAUDE.md) | Demo script contents, how to run the session, pedagogical purpose |
+
+## Learning Arc
+
+1. **Vibe coding demo** — Show AI building real advocacy tools to motivate the module
+2. **Notebook 1** (Task Coding Demo) — Cell-by-cell execution with FAO slaughter data
+3. **Notebook 2** (APIs for Advocacy) — HTTP, JSON, REST with OpenFoodFacts
+4. **Notebook 3** (AI for the Movement) — LLM API calls, tokens, cost, system prompts
+5. **Project pitches** — GitHub workflow exercise: fork → branch → commit → PR → review → merge
+
+## Key APIs Used in This Module
+
+| API | Purpose | Auth |
+|-----|---------|------|
+| Our World in Data CSV | FAO global slaughter data | None |
+| OpenFoodFacts v2 | Vegan product checker by barcode | None |
+| JSONPlaceholder | POST practice (fake API) | None |
+| OpenRouter | LLM calls (GPT-4o-mini, Haiku, Sonnet) | API key via Colab Secrets |
+
+## Cross-References
+
+- Root context: [`../../CLAUDE.md`](../../CLAUDE.md)
+- India launch using these materials: `programs/developer-training-pipeline/india-community/community-strategy.md`
+- Guild pipeline this feeds into: `programs/developer-training-pipeline/guild/operations.md`

--- a/module-2/notebooks/CLAUDE.md
+++ b/module-2/notebooks/CLAUDE.md
@@ -1,0 +1,54 @@
+# Module 2 — Notebooks
+
+Three Google Colab teaching notebooks for the Coding Foundations module. Each uses real advocacy data and real APIs. Designed to run in Colab free tier — no local setup required.
+
+## Files
+
+| File | What It Teaches | APIs / Data |
+|------|----------------|-------------|
+| `module-2-1-task-coding-demo.ipynb` | Task coding (cell-by-cell execution), data loading, filtering, matplotlib charting | FAO animals slaughtered data via Our World in Data CSV |
+| `module-2-2-api-exercise.ipynb` | HTTP methods (GET, POST, PUT, DELETE), JSON parsing, REST APIs | OpenFoodFacts (vegan product checker), JSONPlaceholder (POST practice), hardcoded FAO/IPCC environmental data |
+| `module-2-3-openrouter-ai-for-advocacy.ipynb` | LLM API calls, token economics, model comparison, system prompts | OpenRouter (GPT-4o-mini, Claude Haiku, Claude Sonnet) |
+
+## Notebook Summaries
+
+### module-2-1-task-coding-demo.ipynb — Task Coding Demo: The Scale of Animal Agriculture
+
+Introduces "task coding" — running code one cell at a time, inspecting output before continuing. Students fetch global FAO slaughter data from Our World in Data, filter for world totals in the most recent year, compute per-second kill rates, then chart chicken slaughter over time (line chart) and all major species over time (stacked area chart). Final exercise: students filter for a country of their choice and generate a custom chart. Fallback hardcoded dataset included for offline use.
+
+**Libraries:** `requests`, `csv`, `io`, `matplotlib`
+**Data:** `https://ourworldindata.org/grapher/animals-slaughtered-for-meat.csv`
+**Key concepts:** CSV parsing, dict filtering, matplotlib, data exploration
+
+### module-2-2-api-exercise.ipynb — APIs for Advocacy
+
+Covers how APIs work and why they matter for advocacy tools. Students make GET requests to OpenFoodFacts to check if a product is vegan (by barcode), extract JSON fields including vegan status and palm oil status, practice POST using JSONPlaceholder, parse hardcoded environmental data (livestock emissions, land use, water usage per kg of food) sourced from FAO/IPCC/Poore & Nemecek, and end with an OpenFoodFacts search exercise. Each step includes a "your turn" exercise.
+
+**Libraries:** `requests`, `json`
+**APIs:** OpenFoodFacts v2 (`world.openfoodfacts.org`), JSONPlaceholder (`jsonplaceholder.typicode.com`)
+**Key concepts:** GET, POST, status codes, JSON traversal, HTTP error handling
+
+### module-2-3-openrouter-ai-for-advocacy.ipynb — AI for the Movement
+
+Students make their first LLM API calls. They load an OpenRouter API key from Colab Secrets (never hardcoded), draft a social media post about factory farming, generate a counter-argument response, inspect token usage and calculate per-call cost, compare three models (GPT-4o-mini, Claude Haiku, Claude Sonnet) on the same advocacy fact-check prompt, and build a VEG3 persona using a system prompt. Ends with a cost-control checklist.
+
+**Libraries:** `requests`, `time`, `google.colab`
+**APIs:** OpenRouter (`openrouter.ai/api/v1/chat/completions`)
+**Models used:** `openai/gpt-4o-mini`, `anthropic/claude-3.5-haiku`, `anthropic/claude-sonnet-4`
+**Key concepts:** API authentication, token economics, system prompts, model routing, cost control
+
+## Development Notes
+
+- All notebooks must run on Colab free tier. Do not add dependencies requiring local installation.
+- API keys must use Colab Secrets (`userdata.get(...)`) — never hardcode keys in cells.
+- Each notebook has a fallback path for network errors (especially notebook 1 which fetches a remote CSV).
+- Use cheapest capable models for student exercises. Notebook 3 uses GPT-4o-mini by default.
+- FAO/IPCC data in notebook 2 is hardcoded from peer-reviewed sources — cite them if updated.
+- Use domain-correct terminology: **farmed animal** (not "livestock"), **factory farm** (not "farm"), **slaughterhouse** (not "processing facility").
+
+## Cross-References
+
+- Parent module: `../` (module-2)
+- Exercise built on these APIs: `../project-pitches/` (students pitch tools using these APIs)
+- Vibe coding demo: `../vibe-coding-demo/demo-script.md`
+- Org context: `programs/developer-training-pipeline/india-community/community-strategy.md` (May 2026 launch)

--- a/module-2/project-pitches/CLAUDE.md
+++ b/module-2/project-pitches/CLAUDE.md
@@ -1,0 +1,43 @@
+# Module 2 — Project Pitches
+
+A GitHub workflow exercise where students practice fork → branch → commit → PR → review → merge using real content: pitching an advocacy tech project idea.
+
+This directory is designed to be published as a separate repo (`c4c-project-pitches`) so students can fork it independently. All files here are student-facing.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `README.md` | Student-facing instructions — the full 7-step workflow (fork, branch, write, commit, PR, review, merge) with a pitch template |
+| `CONTRIBUTING.md` | Branch naming conventions, commit message format, what good PR review looks like, merge conflict guidance |
+| `.github/PULL_REQUEST_TEMPLATE.md` | PR template students fill in: pitch summary, category checkboxes, submission checklist, questions for reviewers |
+| `pitches/example-sanctuary-supply-tracker.md` | Example pitch: a supply-sharing platform for animal sanctuaries to match surplus and need by location |
+| `pitches/example-veg3-advocacy-assistant.md` | Example pitch: VEG3 AI chatbot for animal advocates — evidence-based counter-arguments, Telegram + web + API |
+| `pitches/.gitkeep` | Keeps the `pitches/` directory tracked in git before student submissions exist |
+
+## What Students Do
+
+1. Fork this repo to their own GitHub account
+2. Create a branch named `pitch/short-description`
+3. Add a file to `pitches/` using the template in README.md
+4. Commit with message `Add pitch: [project name]`
+5. Open a PR back to the original repo
+6. Review at least one classmate's pitch
+7. Merge after approval
+
+## Pedagogical Purpose
+
+This exercise teaches the professional open-source contribution workflow. It replaces "add your name to a list" exercises with something substantive: students contribute an idea with real advocacy value. The two example pitches (`example-sanctuary-supply-tracker.md` and `example-veg3-advocacy-assistant.md`) give students a concrete quality bar and show the range of projects in scope.
+
+## Instructor Notes
+
+- Publish `project-pitches/` as a separate repo (`c4c-project-pitches`) before bootcamp starts — students fork from that repo, not from `c4c-bootcamp`
+- Example pitches stay in the repo as permanent reference, not as student submissions
+- Merge conflicts are intentional learning opportunities — cover resolution in the next session, do not pre-resolve
+- The PR template enforces the checklist: pitch file in correct folder, template used, commit message format, classmate review done
+
+## Cross-References
+
+- Parent module: `../` (module-2)
+- Notebooks introducing the APIs referenced in many pitches: `../notebooks/`
+- Vibe coding demo showing rapid prototyping: `../vibe-coding-demo/demo-script.md`

--- a/module-2/vibe-coding-demo/CLAUDE.md
+++ b/module-2/vibe-coding-demo/CLAUDE.md
@@ -1,0 +1,44 @@
+# Module 2 — Vibe Coding Demo
+
+A prompt library and teaching guide for demonstrating AI-assisted rapid prototyping in a live or recorded session. Not a notebook — this is instructor-facing material for a 60–90 second screen recording or live demo.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `demo-script.md` | Five worked examples (vague vs. detailed prompts) for advocacy web apps, plus six principles for writing effective prompts, and a bridge section from "vibes" to structured development |
+
+## What demo-script.md Contains
+
+Five pairs of vague/detailed prompts for advocacy-relevant web apps. Each pair shows the quality difference between under-specified and well-specified prompts:
+
+1. **Animal Rescue Counter** — sanctuary animal count grid with animated numbers (Lovable/Bolt/Replit)
+2. **Vegan Ingredient Checker** — paste ingredient list, highlight animal-derived ingredients in red with tooltips
+3. **Carbon Footprint Comparison** — side-by-side meal comparison with proportional bars, Our World in Data source credit
+4. **AI Risk Timeline** — interactive vertical timeline of 8-10 key AI safety milestones
+5. **Protest Sign Generator** — type slogan, pick colour/font, live preview, PNG download
+
+Also includes:
+- A table of three vibe coding tools (Lovable, Bolt, Replit) with free tier limits
+- Six principles for writing good vibe coding prompts
+- A "From Vibes to Structure" section bridging to the structured development skills taught in later modules (project briefs, requirements, tests-before-code, living spec)
+
+## How to Use This in a Session
+
+The demo works best as a screen recording or live share. Recommended flow:
+
+1. Open one of the vibe coding tools (Bolt.new recommended — largest free token budget)
+2. Paste the **vague** prompt, run it, show the result
+3. Paste the **detailed** prompt, run it, show the dramatically better result
+4. Explain the six prompt-writing principles using the contrast as evidence
+5. End on the "From Vibes to Structure" section — this is the bridge to the rest of the course
+
+## Pedagogical Purpose
+
+Students need to see AI code generation working before they feel motivated to learn structured development. This demo establishes that AI can build real-looking advocacy tools quickly — then immediately raises the question "but how do you build something you can actually depend on?" That tension is what the rest of the course resolves.
+
+## Cross-References
+
+- Parent module: `../` (module-2)
+- Notebooks teaching the underlying skills: `../notebooks/`
+- Project pitches exercise applying structured thinking: `../project-pitches/`


### PR DESCRIPTION
## Summary

- Added `module-2/CLAUDE.md` — module-level index with learning arc, subdirectory table, and full API reference table
- Added `module-2/notebooks/CLAUDE.md` — per-notebook summaries with exact APIs, libraries, and key concepts for all three Colab notebooks
- Added `module-2/project-pitches/CLAUDE.md` — file inventory, 7-step student workflow, instructor notes about publishing as separate repo
- Added `module-2/vibe-coding-demo/CLAUDE.md` — contents of demo-script.md, how to run the session, pedagogical purpose
- Updated root `CLAUDE.md` with an "Agent Context Files" table linking to all new docs

## What each notebook covers

| Notebook | What it teaches |
|----------|----------------|
| `module-2-1-task-coding-demo.ipynb` | Task coding (cell-by-cell execution), fetching FAO slaughter data from Our World in Data, filtering + charting with matplotlib |
| `module-2-2-api-exercise.ipynb` | HTTP methods (GET/POST/PUT/DELETE), JSON parsing, OpenFoodFacts vegan checker, hardcoded FAO/IPCC environmental data |
| `module-2-3-openrouter-ai-for-advocacy.ipynb` | LLM API calls via OpenRouter, token economics, model comparison (GPT-4o-mini / Claude Haiku / Claude Sonnet), system prompts |

## Test plan

- [ ] All files listed in CLAUDE.md tables exist on disk (verified with `find`)
- [ ] Cross-references resolve to real files
- [ ] No speciesist language introduced