### PR TITLE
ci: add no-animal-violence detection

### DIFF
--- a/.github/workflows/no-animal-violence.yml
+++ b/.github/workflows/no-animal-violence.yml
@@ -1,0 +1,18 @@
+name: No Animal Violence Check
+on:
+  pull_request:
+    paths:
+      - '**/*.py'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.astro'
+      - '**/*.md'
+      - '**/*.yaml'
+      - '**/*.yml'
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Open-Paws/no-animal-violence-action@main


### PR DESCRIPTION
Adds automated speciesist language detection to all PRs. Part of org-wide rollout. See https://github.com/Open-Paws/no-animal-violence for the 65+ rules enforced.