### PR TITLE
docs: comprehensive README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# AGENTS.md — C4C Bootcamp
+
+## Summary
+
+`c4c-bootcamp` is the teaching materials repository for Code for Compassion Campus bootcamps — the entry point of Open Paws' Layer 1 developer pipeline (Bootcamp → Hackathon → Guild → RDP). It contains three Google Colab notebooks, a GitHub workflow exercise (project pitches), and a vibe coding demo script, all built around real advocacy APIs and movement data. The May 2026 cohort launches in Bengaluru and Mumbai. The CLAUDE.md at the repo root is the authoritative agent context file; this AGENTS.md is its counterpart for non-Claude agent systems.
+
+---
+
+## Status
+
+**Active Development** — Content is live and in use. The May 2026 India cohort is imminent. LMS course content on Campus (the wrapper around these notebooks) has no assigned author as of 2026-04-14 and is a blocker for the May cohort. Graze-CLI is not yet integrated into any curriculum material (smoke test on a non-core-team machine is a prerequisite). The no-animal-violence VS Code extension and pre-commit hook are not yet in curriculum.
+
+**Change implications:** Any edit to a notebook must be verified to run end-to-end on Colab free tier before merging. Any new API introduced must be free-tier accessible or cost-free for students. Do not add Graze-CLI references until the smoke test passes.
+
+---
+
+## Curriculum Structure
+
+```
+module-2/                                      # Coding Foundations — only published module
+├── notebooks/                                 # 3 Google Colab teaching notebooks
+│   ├── module-2-1-task-coding-demo.ipynb      # FAO slaughter data, matplotlib, CSV parsing
+│   ├── module-2-2-api-exercise.ipynb          # OpenFoodFacts, JSONPlaceholder, HTTP methods
+│   └── module-2-3-openrouter-ai-for-advocacy.ipynb  # LLM API calls via OpenRouter
+├── project-pitches/                           # GitHub fork/PR workflow exercise
+│   ├── README.md                              # Student-facing step-by-step instructions
+│   ├── CONTRIBUTING.md                        # Fork/branch/PR workflow guide
+│   ├── pitches/                               # Student pitch submissions (Markdown files)
+│   └── .github/PULL_REQUEST_TEMPLATE.md       # PR template for pitch submissions
+└── vibe-coding-demo/
+    └── demo-script.md                         # Prompt examples for live AI coding demo
+```
+
+**Agent context files (CLAUDE.md tree):**
+
+| File | Covers |
+|------|--------|
+| `CLAUDE.md` | Root: full project context, org placement, settled decisions, India launch, quality gates |
+| `module-2/CLAUDE.md` | Module 2 overview: learning arc, subdirectory index, API table |
+| `module-2/notebooks/CLAUDE.md` | Per-notebook summaries: APIs, libraries, key concepts, dev notes |
+| `module-2/project-pitches/CLAUDE.md` | File inventory, GitHub workflow steps, instructor notes |
+| `module-2/vibe-coding-demo/CLAUDE.md` | Demo script contents, session flow, pedagogical purpose |
+
+---
+
+## Setup Commands
+
+```bash
+# Clone
+git clone https://github.com/Open-Paws/c4c-bootcamp.git
+cd c4c-bootcamp
+
+# Local notebook development
+pip install jupyter matplotlib requests
+jupyter notebook
+
+# Speciesist language check (run before any PR)
+semgrep --config semgrep-no-animal-violence.yaml
+
+# Quality scan
+desloppify scan --path .   # minimum score ≥85
+```
+
+Students use Google Colab exclusively — no local setup required for learners. Colab URLs follow the pattern:
+```
+https://colab.research.google.com/github/Open-Paws/c4c-bootcamp/blob/main/module-2/notebooks/<name>.ipynb
+```
+
+---
+
+## Architecture Decisions
+
+**Notebook format (Google Colab):** All teaching notebooks target Colab free tier. This is a deliberate accessibility decision for the India cohort (constrained connections, no local dev environment assumed). Do not add dependencies that require local installation. Colab Secrets (`userdata.get(...)`) is the only approved mechanism for API keys — never hardcode credentials in cells.
+
+**Real advocacy data from day one:** Every notebook uses real data (FAO slaughter statistics, OpenFoodFacts product data, peer-reviewed environmental footprint figures). This is an identity-formation decision, not just a pedagogy choice. Students encounter the scale of animal agriculture in their first coding exercise.
+
+**OpenRouter as LLM gateway:** Notebook 3 uses OpenRouter rather than direct Anthropic or OpenAI APIs. This avoids vendor lock-in, gives students access to multiple models under one key, and allows cost comparison across providers. Default model is `openai/gpt-4o-mini` (cheapest capable model). Do not switch to a paid-by-default model without updating the cost-control checklist in the notebook.
+
+**Project pitches as a separate publishable repo:** The `module-2/project-pitches/` directory is designed to be deployed as `c4c-project-pitches` — a separate GitHub repo students fork. This gives students a real fork target with a real contribution history. It is kept in this repo for instructor maintainability.
+
+**No liberation rhetoric at the entry point:** Bootcamp materials use systems framing ("animal agriculture is an engineering problem") rather than explicit liberation language in early modules. Identity shift is a deliberate journey. See `CLAUDE.md` for the 2026-04-09 settled decision on identity framing.
+
+**India-aware curriculum framing:** Dairy is the primary entry point (not meat) for the May 2026 Indian cohort. Economic framing ("meaningful AND paid") is required alongside cause framing. Anti-caste tone is a design-level principle, not a disclaimer. See `CLAUDE.md` India section for full detail.
+
+---
+
+## Key APIs and Data Sources
+
+| API / Source | Used In | Auth | Cost |
+|---|---|---|---|
+| Our World in Data CSV (FAO slaughter data) | Notebook 1 | None | Free |
+| OpenFoodFacts v2 | Notebook 2 | None | Free |
+| JSONPlaceholder | Notebook 2 | None | Free |
+| OpenRouter | Notebook 3 | API key (Colab Secrets) | Free tier available |
+
+---
+
+## Integration Points
+
+- **C4C Campus (LMS):** Campus hosts the module/lesson/quiz wrapper around these notebooks. LMS content authorship for May 2026 cohort is currently unassigned (blocker — see status above).
+- **Guild tutorial quests:** After bootcamp, graduates enter the Guild. Five tutorial quests are documented in `programs/developer-training-pipeline/guild/tutorial-quests.md` (strategy repo). Notebooks should reference these as the post-bootcamp on-ramp.
+- **no-animal-violence GitHub Action:** `.github/workflows/no-animal-violence.yml` runs speciesist language checks on every PR. This is non-negotiable — do not disable.
+- **Graze-CLI:** NOT yet integrated. Integration requires a smoke test on a non-core-team machine before any curriculum reference is added.
+- **structured-coding-with-ai:** Tool-specific AI coding instructions (Claude Code rules, Cursor MDC, etc.) should be copied from `structured-coding-with-ai` repo into this project root when needed.
+
+---
+
+## Safe vs. Risky Changes
+
+**Safe:**
+- Editing prose in `demo-script.md` or `project-pitches/README.md`
+- Fixing typos or updating terminology in any `.md` file
+- Adding new pitch examples to `module-2/project-pitches/pitches/`
+- Updating hardcoded environmental data in Notebook 2 with newer peer-reviewed figures (cite source)
+- Adding new prompt examples to the vibe coding demo
+
+**Requires care:**
+- Editing notebook cells — verify the full notebook runs end-to-end in Colab free tier after any change
+- Changing model names in Notebook 3 — check current OpenRouter model IDs and update the cost-control checklist
+- Changing the OpenFoodFacts barcode in Notebook 2 — verify the product still exists and is correctly flagged as vegan/not vegan
+- Adding new Python dependencies — must be available without pip install (pre-installed in Colab) or clearly documented as a `!pip install` cell
+
+**Risky (requires explicit decision):**
+- Adding Graze-CLI references — blocked until smoke test passes
+- Adding the no-animal-violence VS Code extension or pre-commit hook to curriculum — requires a curriculum decision
+- Adding liberation framing to early-module content — see identity-framing settled decision in `CLAUDE.md`
+- Changing the project-pitches directory structure — may break the live `c4c-project-pitches` repo if it has already been published for a cohort
+- Adding modules — must follow `module-2/` structure and include full CLAUDE.md tree
+
+---
+
+## Language Rules
+
+All content must use domain-correct terminology:
+
+- **Farmed animal** — not "livestock" (industry framing that normalises commodification)
+- **Factory farm** — not "farm" (scale and conditions matter)
+- **Slaughterhouse** — use precisely, not euphemisms
+- **Campaign** — organised advocacy effort (not "project")
+- **Sanctuary** — permanent animal care facility (not "shelter" or "foster")
+
+The `no-animal-violence` semgrep ruleset enforces 65+ patterns on every PR. Run `semgrep --config semgrep-no-animal-violence.yaml` before submitting any pull request touching `.py`, `.ipynb`, `.md`, or config files.
+
+---
+
+## TODOs
+
+- [ ] Assign LMS content author for May 2026 cohort (blocker — escalate if not resolved by April 15)
+- [ ] Complete Graze-CLI smoke test on a non-core-team machine; then add curriculum references
+- [ ] Add India-specific framing to Notebook 1 (dairy entry point, economic framing, Ambedkarite tone)
+- [ ] Add Guild tutorial quest references to Notebook 3 (post-bootcamp on-ramp)
+- [ ] Decide whether to introduce no-animal-violence VS Code extension and pre-commit hook in bootcamp
+- [ ] Add Module 1 (non-coding foundations) materials when ready
+- [ ] Add Module 3+ as curriculum develops
+- [ ] Verify all notebook Colab URLs are still valid after any repo restructure

--- a/README.md
+++ b/README.md
@@ -1,64 +1,209 @@
 # C4C Bootcamp
 
-**Teaching developers to build AI tools for animal liberation, climate action, and AI safety.**
+**Status:** ![Active Development](https://img.shields.io/badge/status-active%20development-yellow) | Part of the [Open Paws](https://github.com/Open-Paws) ecosystem
 
-Code for Compassion Campus runs intensive bootcamps that turn developers into advocacy technologists. This repository contains the teaching materials, exercises, and demo scripts used across the curriculum.
+Teaching developers to build AI tools for animal liberation, climate action, and AI safety.
 
-Every exercise uses real advocacy data, real movement APIs, and real problems. No generic weather apps. No toy examples. Students build tools that matter from day one.
+Code for Compassion Campus (C4C) runs intensive bootcamps that turn developers into advocacy technologists. This repository contains the teaching materials, exercises, and demo scripts used across the curriculum. Every exercise uses real advocacy data, real movement APIs, and real problems — no toy examples, no generic starter apps. Students build tools that matter from day one.
+
+---
+
+## What This Bootcamp Teaches
+
+Students leave with the ability to:
+
+- Fetch, parse, and visualise real-world advocacy datasets (FAO slaughter statistics, environmental footprint data)
+- Call external APIs to build practical movement tools (food product checkers, LLM-powered assistants)
+- Make direct LLM API calls, compare models, understand token economics, and control cost
+- Use the professional open-source workflow (fork → branch → commit → PR → review → merge) to contribute to real repositories
+- Rapidly prototype advocacy tools using AI-assisted code generation
+
+The bootcamp is the entry point of the Layer 1 developer pipeline:
+
+```
+Bootcamp → Hackathon → Guild → Resident Developer Programme (RDP)
+```
+
+---
+
+## Who This Is For
+
+**Target audience:** Developers new to advocacy technology — typically engineers with some Python or web development experience who want to apply their skills to animal liberation, climate action, or AI safety.
+
+**Skill level:** Beginner to intermediate. Module 2 (Coding Foundations) assumes familiarity with basic programming concepts but no prior experience with APIs or LLMs.
+
+**Delivery context:** Live cohorts with an instructor. Notebooks are designed for Google Colab — no local setup required for students. The May 2026 cohort runs in Bengaluru and Mumbai.
+
+---
+
+## Curriculum Map
+
+The curriculum is organised into numbered modules. Currently published:
+
+### Module 2 — Coding Foundations
+
+The first hands-on coding module. Students go from zero to making real API calls and LLM requests using advocacy data and movement APIs.
+
+**Learning arc:**
+
+| Step | Activity | What It Teaches |
+|------|----------|----------------|
+| 1 | Vibe Coding Demo | Show AI building real advocacy tools; motivate structured thinking |
+| 2 | Notebook 1: Task Coding Demo | Cell-by-cell execution, CSV parsing, matplotlib, FAO slaughter data |
+| 3 | Notebook 2: APIs for Advocacy | HTTP methods, JSON parsing, REST APIs, OpenFoodFacts |
+| 4 | Notebook 3: AI for the Movement | LLM API calls, token economics, model comparison, system prompts |
+| 5 | Project Pitches | Fork → branch → commit → PR → review → merge GitHub workflow |
+
+**Notebooks (Google Colab):**
+
+| Notebook | What It Teaches | Data / APIs |
+|----------|----------------|-------------|
+| [`module-2-1-task-coding-demo.ipynb`](module-2/notebooks/module-2-1-task-coding-demo.ipynb) | Task coding, data exploration, matplotlib charting | FAO animals-slaughtered data via Our World in Data CSV |
+| [`module-2-2-api-exercise.ipynb`](module-2/notebooks/module-2-2-api-exercise.ipynb) | HTTP GET/POST, JSON parsing, REST APIs | OpenFoodFacts (vegan product checker), JSONPlaceholder, FAO/IPCC environmental data |
+| [`module-2-3-openrouter-ai-for-advocacy.ipynb`](module-2/notebooks/module-2-3-openrouter-ai-for-advocacy.ipynb) | LLM calls, token economics, model routing, system prompts | OpenRouter (GPT-4o-mini, Claude Haiku, Claude Sonnet) |
+
+**Supporting materials:**
+
+| Directory | Contents |
+|-----------|----------|
+| [`module-2/project-pitches/`](module-2/project-pitches/) | Standalone GitHub workflow exercise — students fork, branch, commit, and open a PR to submit a project idea |
+| [`module-2/vibe-coding-demo/`](module-2/vibe-coding-demo/) | Prompt examples for a 60–90 second live or recorded AI code-generation demo |
+
+---
+
+## Prerequisites
+
+Students should have:
+
+- A GitHub account
+- A Google account (for Colab)
+- Basic programming familiarity (variables, loops, functions in any language)
+- An OpenRouter account for Notebook 3 (free tier is sufficient — API key loaded via Colab Secrets)
+
+No local Python installation is required. All notebooks run on Google Colab free tier.
+
+---
+
+## Setup
+
+### For Students
+
+Your instructor will share direct links to each notebook and the project pitches repo. You do not need to clone this repository.
+
+Open notebooks directly in Colab:
+
+```
+https://colab.research.google.com/github/Open-Paws/c4c-bootcamp/blob/main/module-2/notebooks/<notebook-name>.ipynb
+```
+
+For Notebook 3, add your OpenRouter API key to Colab Secrets (key icon in the left sidebar) under the name `OPENROUTER_API_KEY`. Never paste your key directly into a cell.
+
+### For Instructors
+
+Clone the repo:
+
+```bash
+git clone https://github.com/Open-Paws/c4c-bootcamp.git
+cd c4c-bootcamp
+```
+
+For local notebook development:
+
+```bash
+pip install jupyter matplotlib requests
+jupyter notebook
+```
+
+The `module-2/project-pitches/` directory is designed to be published as a separate repository (`c4c-project-pitches`) for students to fork. Copy the contents there before each cohort or point students to the live version.
+
+---
+
+## How to Work Through the Materials
+
+**Recommended order for a cohort session:**
+
+1. Instructor runs the **vibe coding demo** live or plays the recording — establishes what is possible and sets expectations for structured prompting
+2. Students open **Notebook 1** in Colab, work cell by cell, complete the country-filter exercise at the end
+3. Students open **Notebook 2**, step through each API call, complete the "your turn" exercises
+4. Students open **Notebook 3**, load their API key via Colab Secrets, run the model comparison, build the VEG3 persona
+5. Instructor publishes the **project pitches** repo — students fork it, write a pitch, open a PR, review a classmate's PR, merge
+
+Each notebook takes approximately 45–90 minutes. The project pitches exercise takes approximately 60 minutes with instructor support.
+
+---
+
+## Connection to C4C Campus
+
+The bootcamp delivers the hands-on coding component of the [Code for Compassion Campus](https://campus.openpaws.ai) curriculum. Campus hosts the LMS content (modules, lessons, quizzes) that wraps these materials. After completing the bootcamp, graduates are on-ramped into the **Guild** — a paid marketplace for advocacy technology quests.
+
+Five tutorial quests are ready in `programs/developer-training-pipeline/guild/tutorial-quests.md` (strategy repo) and are referenced as the post-bootcamp on-ramp in the notebooks.
+
+---
 
 ## Repository Structure
 
 ```
-module-2/
-├── notebooks/
-│   ├── module-2-1-task-coding-demo.ipynb
-│   ├── module-2-2-api-exercise.ipynb
-│   └── module-2-3-openrouter-ai-for-advocacy.ipynb
-├── project-pitches/
-│   ├── README.md
-│   ├── CONTRIBUTING.md
-│   ├── pitches/
-│   └── .github/PULL_REQUEST_TEMPLATE.md
-└── vibe-coding-demo/
-    └── demo-script.md
+c4c-bootcamp/
+├── module-2/
+│   ├── notebooks/
+│   │   ├── module-2-1-task-coding-demo.ipynb
+│   │   ├── module-2-2-api-exercise.ipynb
+│   │   └── module-2-3-openrouter-ai-for-advocacy.ipynb
+│   ├── project-pitches/
+│   │   ├── README.md                          # Student-facing instructions
+│   │   ├── CONTRIBUTING.md                    # Fork/branch/PR workflow guide
+│   │   ├── pitches/                           # Student pitch submissions
+│   │   └── .github/PULL_REQUEST_TEMPLATE.md
+│   └── vibe-coding-demo/
+│       └── demo-script.md                     # Prompt examples for live demo
+├── CLAUDE.md                                  # Agent context (authoritative project guide)
+└── .github/workflows/
+    ├── auto-merge.yml
+    └── no-animal-violence.yml                 # Speciesist language check on PRs
 ```
 
-## Module 2 — Coding Foundations
-
-### Notebooks (Google Colab)
-
-Three teaching notebooks designed for Google Colab. Students open them directly from GitHub and save a copy to their own Drive.
-
-| Notebook | What It Teaches | Data/APIs Used |
-|----------|----------------|----------------|
-| Task Coding Demo | Cell-by-cell execution, data exploration, matplotlib | FAO animal slaughter data via Our World in Data |
-| APIs for Advocacy | HTTP methods, JSON parsing, REST APIs | OpenFoodFacts (vegan product checker), JSONPlaceholder |
-| AI for the Movement | LLM API calls, tokens, cost, system prompts | OpenRouter (GPT-4o-mini, Claude Haiku, Claude Sonnet) |
-
-### Project Pitches (GitHub Exercise)
-
-A standalone exercise repository where students practice the fork → branch → commit → PR → review → merge workflow. Instead of adding their names to a list, students pitch a project idea — a tool for animal advocacy, climate action, or AI safety.
-
-The `project-pitches/` directory contains all the files needed to set up the `c4c-project-pitches` repository as a separate repo for students to fork. See the README inside that directory for the full student-facing instructions.
-
-### Vibe Coding Demo
-
-A reproducible demo script for screen-recording a 60–90 second vibe coding session. Builds an advocacy-relevant web tool using AI code generation to demonstrate rapid prototyping.
-
-## How to Use These Materials
-
-**Instructors:** Clone this repo. Notebooks can be opened directly in Colab via GitHub URL. The project-pitches directory should be published as a separate repo (`c4c-project-pitches`) for students to fork.
-
-**Students:** Your instructor will share direct links to each notebook and the project pitches repo. You don't need to clone this repository.
+---
 
 ## Tech Stack
 
-- Python 3 (notebooks)
-- Google Colab (execution environment)
-- OpenRouter (LLM API gateway)
-- OpenFoodFacts API (product data)
-- Our World in Data (animal agriculture statistics)
-- GitHub (version control exercise)
+| Technology | Role |
+|------------|------|
+| Python 3 | Notebook language |
+| Google Colab | Execution environment (no local install required) |
+| OpenRouter | LLM API gateway (GPT-4o-mini, Claude Haiku, Claude Sonnet) |
+| OpenFoodFacts API | Vegan product data |
+| Our World in Data | FAO animal agriculture statistics |
+| GitHub | Version control exercise platform |
+
+---
+
+## Contributing
+
+### Adding a Notebook
+
+1. Place the notebook in `module-N/notebooks/` where N is the module number
+2. Ensure it runs completely on Colab free tier with no local dependencies
+3. Load any API keys via `google.colab.userdata.get(...)` — never hardcoded
+4. Use domain-correct terminology: **farmed animal** (not "livestock"), **factory farm** (not "farm"), **slaughterhouse** (not "processing facility")
+5. Update `module-N/notebooks/CLAUDE.md` with a summary row
+
+### Adding a Module
+
+Create `module-N/` following the structure of `module-2/`. Include a `CLAUDE.md` in the module root and in each subdirectory.
+
+### Adding a Project Pitch
+
+See [`module-2/project-pitches/README.md`](module-2/project-pitches/README.md) and [`module-2/project-pitches/CONTRIBUTING.md`](module-2/project-pitches/CONTRIBUTING.md) for the student-facing workflow.
+
+### Code Quality
+
+All pull requests are checked for speciesist language via the `no-animal-violence` GitHub Action. Run locally with:
+
+```bash
+semgrep --config semgrep-no-animal-violence.yaml
+```
+
+---
 
 ## License
 


### PR DESCRIPTION
## Summary

- **README.md** — Expanded from 3 KB to a comprehensive guide covering: status badge + ecosystem link, what the bootcamp teaches and who it is for, full curriculum map with learning arc table, prerequisites, student and instructor setup instructions, step-by-step guide for working through materials, connection to C4C Campus and the Guild pipeline, full repo structure diagram, tech stack table, and contributing guide (adding notebooks, modules, pitches, and quality gate commands).

- **AGENTS.md** — New file providing agent/AI-assistant context: one-paragraph summary, status with change implications (including May 2026 India cohort blockers), complete curriculum structure with key file index, setup commands, architecture decisions (Colab-first, real advocacy data, OpenRouter gateway, project-pitches as deployable repo, identity-framing settled decisions, India-aware framing), API table, integration points (Campus LMS, Guild quests, no-animal-violence CI, Graze-CLI blocker), safe vs. risky change classification, language rules, and a prioritised TODO list.

## What was not changed

`CLAUDE.md` was left untouched — it is the authoritative agent context for Claude Code and already comprehensive. `AGENTS.md` is its counterpart for other agent systems and does not duplicate it.

## Test plan

- [ ] Verify all internal links in README.md resolve correctly (notebook files, CONTRIBUTING.md, CLAUDE.md)
- [ ] Verify Colab notebook URLs open correctly using the pattern documented in README.md
- [ ] Confirm no speciesist language introduced (no-animal-violence CI will check this automatically)
- [ ] Confirm AGENTS.md TODO list accurately reflects current blockers against CLAUDE.md status section
