### PR TITLE
chore(docs): drop refs to deleted repos (graze-cli, gary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   project_status: active-development
   difficulty: beginner-intermediate
   skill_tags: python, jupyter, llm-apis, rest-apis, data-visualisation, git-workflow
-  related_repos: platform, graze-cli, structured-coding-with-ai, gary
+  related_repos: platform, structured-coding-with-ai
 -->
 
 # C4C Bootcamp


### PR DESCRIPTION
Open-Paws/graze-cli and Open-Paws/gary are being deleted. `README.md` `related_repos` metadata still listed both; stripped.

Closes #27